### PR TITLE
Fix typo

### DIFF
--- a/UE4_Online_Notes.md
+++ b/UE4_Online_Notes.md
@@ -39,7 +39,7 @@ The server can be run by one player. I does not need to be in a different machin
 > Official [doc](https://docs.unrealengine.com/en-US/Gameplay/Networking/Server/index.html).
 
 # Authority & Replication
-To detect, distinguish or decide code to be run in the server and/or in the clients, the function `bool` [AActor::HasAuthority()](https://docs.unrealengine.com/en-US/API/Runtime/Engine/GameFramework/AActor/HasAuthority/index.html), returns `true` if it's on the server and `false` otherwise.
+To detect, distinguish or decide code to be run in the server and/or in the clients, the function `bool` [AActor::HasAuthority()](https://docs.unrealengine.com/en-US/API/Runtime/Engine/GameFramework/AActor/HasAuthority/index.html), returns `true` if this code is being run on the server and `false` otherwise.
 
 An `AActor` is one of the building blocks to provide replication through the network. To achieve a certain property to be replicated (updated/noticed) across the clients by the server, **both** the `AAcator` and the wanted `UProperty` needs to be set as `Replicated`.
 
@@ -77,6 +77,5 @@ void AMyActor::Tick(float DeltaTime)
 But if, for example we had implemented this to be run only in the client (i.e. `if(!HasAuthority)`), we would see in the client the object instantiation of `AMyActor` moving **but**, as the server is **authoritative**, we would collide with the `AMyActor` object even if we don't see it (we would be seeing it in a different place after the movement!). This is because our movement is *validated* in the server, and the `AMyActor`object has not moved as to the server's *eyes*.
 
 > Official [doc](https://docs.unrealengine.com/en-US/Gameplay/Networking/Actors/Components/index.html).
-
 
 

--- a/UE4_Online_Notes.md
+++ b/UE4_Online_Notes.md
@@ -39,7 +39,7 @@ The server can be run by one player. I does not need to be in a different machin
 > Official [doc](https://docs.unrealengine.com/en-US/Gameplay/Networking/Server/index.html).
 
 # Authority & Replication
-To detect, distinguish or decide code to be run in the server and/or in the clients, the function `bool` [AAcator::HasAuthority()](https://docs.unrealengine.com/en-US/API/Runtime/Engine/GameFramework/AActor/HasAuthority/index.html), returns `true` if it's on the server and `false` otherwise.
+To detect, distinguish or decide code to be run in the server and/or in the clients, the function `bool` [AActor::HasAuthority()](https://docs.unrealengine.com/en-US/API/Runtime/Engine/GameFramework/AActor/HasAuthority/index.html), returns `true` if it's on the server and `false` otherwise.
 
 An `AActor` is one of the building blocks to provide replication through the network. To achieve a certain property to be replicated (updated/noticed) across the clients by the server, **both** the `AAcator` and the wanted `UProperty` needs to be set as `Replicated`.
 


### PR DESCRIPTION
This commit fixes a typo for the class AActor being documented.

This pull request is being created to play a bit on github.